### PR TITLE
add assertion count in report

### DIFF
--- a/test-report-junit-xml/src/test_report_junit_xml/core.clj
+++ b/test-report-junit-xml/src/test_report_junit_xml/core.clj
@@ -66,6 +66,7 @@
     {:tag :testsuite
      :attrs {:name (-> test-ns :ns ns-name)
              :tests (:test counts)
+             :assertions (:assertion counts)
              :errors (:error counts)
              :failures (:fail counts)
              :time (-> test-ns :time nanos->secs)}


### PR DESCRIPTION
Hi Haines, 
In my situation the assertion count is meaningful. (My project needs dynamic test cases organized in Markdown format which are run as dynamic numbers assertion in 3 or 4 tests)
As it's included in the original output like this.
```
Ran 4 tests containing 156 assertions.
0 failures, 0 errors.
```
I'm not sure whether it is a wide need, so I add it in my fork.
What do you think about the report with assertion count?
